### PR TITLE
refactor: reimplemented cache using LruCache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,16 @@ smallvec = "1.8.0"
 
 tokio = { version = "1.0", features = ["sync", "time", "macros", "rt-multi-thread"] }
 tokio-tungstenite = "0.17.1"
+futures-util = "0.3" 
 tracing = "0.1"
 lazy_static = "1.4"
-
-futures-delay-queue = { version = "=0.5.1", default-features = false, features = ["use-tokio"] }
-futures-intrusive = "=0.4"
-futures-util = "=0.3.21"
 
 serde = { version = "1.0", features = ["derive"] }
 json = { version = "1.0", package = "serde_json" }
 
 bs58 = "0.4"
 base64 = "0.13"
-zstd = "0.9"
+zstd = "0.11"
 prometheus = { version = "0.13", default-features = false, features = ["process"] }
+lru = "0.7.5"
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,17 +1,24 @@
 use lazy_static::lazy_static;
 use prometheus::{
-    register_int_counter_vec, register_int_gauge, register_int_gauge_vec, IntCounterVec, IntGauge,
-    IntGaugeVec,
+    register_int_counter, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
+    IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 
 /// Collection of different application metrics
 pub struct Metrics {
     pub cached_entries: IntGaugeVec,
+    pub corrupted_programs: IntCounter,
+    pub evictions: IntCounterVec,
     pub active_subscriptions: IntGaugeVec,
+    pub inflight_subscriptions: IntGaugeVec,
     pub active_ws_connections: IntGauge,
+    pub ws_reconnects: IntCounterVec,
     pub ws_data_received: IntCounterVec,
-    pub cache_size: IntGauge,
+    pub cache_size: IntGaugeVec,
 }
+
+pub(crate) const ACCOUNTS: &[&str] = &["accounts"];
+pub(crate) const PROGRAMS: &[&str] = &["programs"];
 
 lazy_static! {
     /// Globally accessable metrics container
@@ -29,6 +36,12 @@ lazy_static! {
             &["id", "subscription"]
         ).unwrap();
 
+        let inflight_subscriptions = register_int_gauge_vec!(
+            "inflight_subscriptions",
+            "Number of unconfirmed websocket subscriptions per websocket worker",
+            &["id", "subscription"]
+        ).unwrap();
+
         let active_ws_connections = register_int_gauge!(
             "active_ws_connections",
             "Number of active websocket connections/workers",
@@ -40,17 +53,38 @@ lazy_static! {
             &["id"]
         ).unwrap();
 
-        let cache_size = register_int_gauge!(
-            "cache_size",
-            "Memory amount occupied by cache",
+        let ws_reconnects = register_int_counter_vec!(
+            "ws_reconnects",
+            "Number of times each websocket worker was forced to reconnect",
+            &["id"]
         ).unwrap();
 
+        let cache_size = register_int_gauge_vec!(
+            "cache_size",
+            "Memory amount occupied by cache",
+            &["type"]
+        ).unwrap();
+
+        let evictions = register_int_counter_vec!(
+            "evictions",
+            "Number of records which were evicted due to full cache",
+            &["type"]
+        ).unwrap();
+
+        let corrupted_programs = register_int_counter!(
+            "corrupted_programs",
+            "Number of programs which were corrupted in cache after one or more of their accounts were deleted"
+        ).unwrap();
 
         Metrics {
             cached_entries,
             active_subscriptions,
+            inflight_subscriptions,
             active_ws_connections,
+            ws_reconnects,
             ws_data_received,
+            evictions,
+            corrupted_programs,
             cache_size,
         }
     };


### PR DESCRIPTION
TTL based caching was abandoned in favour of bounded LRU cache, which is
simpler to manage and to maintain its related logic, also this approach
removes the overhead of asynchronous ttl expiration tracking which
caused excessive memory consumption when using futures-delay-queue